### PR TITLE
browser: If chrome isn't closed properly, warn and forcibly close

### DIFF
--- a/pycdp/browser.py
+++ b/pycdp/browser.py
@@ -1,6 +1,7 @@
 import os
 import signal
 import shutil
+import warnings
 import tempfile
 import subprocess
 import typing as t
@@ -109,6 +110,13 @@ class BrowserLauncher(LoggerMixin):
                 self._logfile.close()
             if not self._keep_profile:
                 shutil.rmtree(self._profile, ignore_errors=True)
+
+    def __del__(self):
+        warnings.warn("The chrome instance was not closed properly with chrome.kill(); issuing SIGKILL.")
+        if os.name == 'posix':
+            os.killpg(os.getpgid(self._process.pid), signal.SIGKILL)
+        else:
+            self._process.kill()
 
     def _build_launch_cmdline(self) -> t.List[str]:
         raise NotImplementedError


### PR DESCRIPTION
This isn't the nicest since no cleanup is done, but it sure beats a memory leak.

I'm using `warnings.warn()` instead of the `logging.warning()` since this is [in library code, the issue is avoidable, and the client application should be modified to eliminate the warning](https://docs.python.org/3/howto/logging.html):

> [`warnings.warn()`](https://docs.python.org/3/library/warnings.html#warnings.warn) in library code if the issue is avoidable and the client application should be modified to eliminate the warning  
> [`logging.warning()`](https://docs.python.org/3/library/logging.html#logging.warning) if there is nothing the client application can do about the situation, but the event should still be noted

Question: Is there a nicer way to kill it? I just copied the code from the `.kill()` method. Why does `posix` get a separate treatment?