### PR TITLE
Create UnkownEvent and UnkownObject classes for unkown CDP events 

### DIFF
--- a/pycdp/cdp/util.py
+++ b/pycdp/cdp/util.py
@@ -5,6 +5,49 @@ T_JSON_DICT = typing.Dict[str, typing.Any]
 _event_parsers = dict()
 
 
+class UnknownObject:
+    def __init__(self, elements: dict):
+        self._elements = elements
+
+    def __getattr__(self, name):
+        # some names are appended a `_` so they don't collide with the python namespace
+        # example: id_ and type_
+        name = name.removesuffix('_')
+
+        if name not in self._elements:
+            raise AttributeError
+
+        return self._elements[name]
+
+    @classmethod
+    def from_json(cls, json: T_JSON_DICT):
+        if isinstance(json, dict):
+            value = {key: cls.from_json(val) for key, val in json.items()}
+            obj = cls(value)
+        elif isinstance(json, list):
+            obj = [cls.from_json(val) for val in json]
+        else:
+            obj = json
+
+        return obj
+
+
+class UnknownEvent(UnknownObject):
+    def __init__(self, name, elements):
+        super().__init__(elements)
+        self.name = name
+
+    @classmethod
+    def from_json(cls, json: T_JSON_DICT):
+        name = json['method']
+        obj = UnknownObject.from_json(json['params'])
+
+        if isinstance(obj, UnknownObject):
+            return cls(name, obj._elements)
+
+        return obj
+
+
 def event_class(method):
     ''' A decorator that registers a class as an event class. '''
     def decorate(cls):
@@ -15,4 +58,7 @@ def event_class(method):
 
 def parse_json_event(json: T_JSON_DICT) -> typing.Any:
     ''' Parse a JSON dictionary into a CDP event. '''
+    if json['method'] not in _event_parsers:
+        return UnknownEvent.from_json(json)
+
     return _event_parsers[json['method']].from_json(json['params'])

--- a/pycdp/gen/generate.py
+++ b/pycdp/gen/generate.py
@@ -949,7 +949,8 @@ def generate_init(init_path, domains):
     '''
     with init_path.open('w') as init_file:
         init_file.write(INIT_HEADER)
-        init_file.write('from . import ({})'.format(', '.join(domain.module for domain in domains)))
+        init_file.write('from . import ({})\n'.format(', '.join(domain.module for domain in domains)))
+        init_file.write('from .util import UnknownEvent, UnknownObject')
 
 
 def generate_docs(docs_path, domains):


### PR DESCRIPTION
CDP updates periodically, and sometimes, new events are added. Python-cdp throws an error for these kind of events, because there isn't a corresponding class for them. This, of course, can be solved by updating the repository with the new CDP specification.

However, this makes tools that might have python-cdp as a dependency, unusable, after a while. Especially when these events are generated frequently. However, those tools probably don't need the newly added events. They might still be functional.

This PR makes python-cdp treat the case where a CDP event is unkown. It creates a generic class called UnkownEvent that can be used like any other event class. It can contain instances of UnkownObject, depending on the structure of the json.

Additionally, tools that use python-cdp can read the new events by working with instances of UnknownEvent.

After this, python-cdp can potentially continue to work for newer versions of cdp, without syncing the repo with the spec. This, however, doesn't solve the case where existing CDP events or objects are updated. 